### PR TITLE
Test coverage for the org.aeonbits.owner.Converters.UNSUPPORTED#convert() method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .idea/
 target/
 owner.iml
+
+# Eclipse IDE
+.classpath
+.settings
+.project

--- a/src/test/java/org/aeonbits/owner/ConfigTest.java
+++ b/src/test/java/org/aeonbits/owner/ConfigTest.java
@@ -242,6 +242,20 @@ public class ConfigTest {
         assertEquals("Good Afternoon", config.salutation());
     }
 
+    @Sources({"file:${user.dir}/src/test/resources/unsupported.properties"})
+    public interface UnsupportedConfig extends Config {
+        public static class UnsupportedType {
+        }
+
+        public UnsupportedType unsupportedTypeProperty();
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testUnsupportedClassConverting() throws Exception {
+        UnsupportedConfig cfg = ConfigFactory.create(UnsupportedConfig.class);
+        cfg.unsupportedTypeProperty();
+    }
+
     /**
      * @author Luigi R. Viggiano
      */

--- a/src/test/resources/unsupported.properties
+++ b/src/test/resources/unsupported.properties
@@ -1,0 +1,1 @@
+unsupportedTypeProperty =


### PR DESCRIPTION
Is it OK that the UnsupportedOperationException is thrown during the first (or every) property accessor invocation?
