### PR TITLE
Fix issue with string replace methods removing backslashes

### DIFF
--- a/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -69,7 +69,13 @@ class StrSubstitutor {
         while (m.find()) {
             String var = m.group(1);
             String value = values.getProperty(var);
-            String replacement = (value != null) ? replace(value) : "";
+	        String replacement;
+	        if (value != null) {
+		        String safeValue = value.replace("\\", "\\\\");
+		        replacement = replace(safeValue);
+	        } else {
+		        replacement = "";
+	        }
             m.appendReplacement(sb, replacement);
         }
         m.appendTail(sb);

--- a/src/main/java/org/aeonbits/owner/Util.java
+++ b/src/main/java/org/aeonbits/owner/Util.java
@@ -63,10 +63,12 @@ abstract class Util {
     }
 
     static String expandUserHome(String text) {
-        if (text.equals("~"))
-            return System.getProperty("user.home");
-        if (text.indexOf("~/") == 0 || text.indexOf("file:~/") == 0 || text.indexOf("jar:file:~/") == 0)
-            return text.replaceFirst("~/", System.getProperty("user.home") + "/");
+	    if (text.equals("~")) {
+		    return System.getProperty("user.home");
+	    } else if (text.indexOf("~/") == 0 || text.indexOf("file:~/") == 0 || text.indexOf("jar:file:~/") == 0) {
+		    String safeHome = System.getProperty("user.home").replace("\\", "\\\\");
+		    return text.replaceFirst("~/", safeHome + "/");
+	    }
         return text;
     }
 

--- a/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -31,11 +31,11 @@ public class StrSubstitutorTest {
     public void shouldReplaceVariables() {
         Properties values = new Properties();
         values.setProperty("animal", "quick brown fox");
-        values.setProperty("target", "lazy dog");
+        values.setProperty("target", "lazy\\slow dog");
         String templateString = "The ${animal} jumped over the ${target}.";
         StrSubstitutor sub = new StrSubstitutor(values);
         String resolvedString = sub.replace(templateString);
-        assertEquals("The quick brown fox jumped over the lazy dog.", resolvedString);
+        assertEquals("The quick brown fox jumped over the lazy\\slow dog.", resolvedString);
     }
 
     @Test

--- a/src/test/java/org/aeonbits/owner/importedprops/WithImportedPropertiesTest.java
+++ b/src/test/java/org/aeonbits/owner/importedprops/WithImportedPropertiesTest.java
@@ -49,6 +49,8 @@ public class WithImportedPropertiesTest {
         Properties propsFromTest = new Properties();
         propsFromTest.setProperty("external", "propsFromTest");
 
+	    String winPath = "C:\\windows\\path";
+	    System.setProperty("value.with.backslash", winPath);
         String userHome = System.getProperty("user.home");
         String envHome = System.getenv("HOME");
         WithImportedProperties conf =
@@ -56,6 +58,7 @@ public class WithImportedPropertiesTest {
                         propsFromTest, System.getProperties(), System.getenv());
         assertEquals(userHome, conf.userHome());
         assertEquals(envHome, conf.envHome());
+	    assertEquals(winPath, conf.valueWithBackslash());
         assertEquals("testing replacement from propsFromTest properties file.", conf.someValue());
     }
 
@@ -70,5 +73,8 @@ public class WithImportedPropertiesTest {
 
         @DefaultValue("${HOME}")
         String envHome();
+
+	    @DefaultValue("${value.with.backslash}")
+	    String valueWithBackslash();
     }
 }


### PR DESCRIPTION
Java string replace methods don't properly handle backslashes in the replacement string.
See http://stackoverflow.com/questions/9575116/forward-slash-in-java-regex

Suggestion as of that SO page is to replace backslash with double backslash ("\" with "\\") in the replacement string prior to replacing.

I ran into this because user.home on windows machines is something like C:\Users\NiXXeD, and several of the tests failed for me on a clean repo. I updated the affected tests to reproduce the issue prior to making changes.
