### PR TITLE
Implement map based properties per issue #41.

### DIFF
--- a/src/main/java/org/aeonbits/owner/Config.java
+++ b/src/main/java/org/aeonbits/owner/Config.java
@@ -88,6 +88,16 @@ public interface Config {
         String value();
     }
 
+	/**
+	 * The key used for map properties (map1 in map1.value1). If not present, values such as map1.value1 will be treated as standard properties.
+	 */
+	@Retention(RUNTIME)
+	@Target(METHOD)
+	@Documented
+	@interface MapValue {
+		String value();
+	}
+
     /**
      * Specifies the policy type to use to load the {@link org.aeonbits.owner.Config.Sources} files for properties.
      *

--- a/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
+++ b/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 import static org.aeonbits.owner.Config.DisableableFeature.PARAMETER_FORMATTING;
 import static org.aeonbits.owner.Config.DisableableFeature.VARIABLE_EXPANSION;
@@ -74,12 +75,16 @@ class PropertiesInvocationHandler implements InvocationHandler {
 
     private Object resolveProperty(Method method, Object... args) {
         String key = key(method);
-        String value = propertiesManager.getProperty(key);
-        if (value == null)
-            return null;
-        Object result = convert(method, method.getReturnType(), format(method, expandVariables(method, value), args));
-        if (result == Converters.NULL) return null;
-        return result;
+	    if (method.getReturnType().equals(Map.class)) {
+		    return propertiesManager.getObject(key);
+	    } else {
+		    String value = propertiesManager.getProperty(key);
+		    if (value == null)
+			    return null;
+		    Object result = convert(method, method.getReturnType(), format(method, expandVariables(method, value), args));
+		    if (result == Converters.NULL) return null;
+		    return result;
+	    }
     }
 
     private String format(Method method, String format, Object... args) {

--- a/src/main/java/org/aeonbits/owner/PropertiesManager.java
+++ b/src/main/java/org/aeonbits/owner/PropertiesManager.java
@@ -49,6 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.Collections.synchronizedList;
 import static org.aeonbits.owner.Config.LoadType.FIRST;
 import static org.aeonbits.owner.PropertiesMapper.defaults;
+import static org.aeonbits.owner.PropertiesMapper.mapValues;
 import static org.aeonbits.owner.Util.asString;
 import static org.aeonbits.owner.Util.eq;
 import static org.aeonbits.owner.Util.ignore;
@@ -170,6 +171,7 @@ class PropertiesManager implements Reloadable, Accessible, Mutable {
             loading = true;
             defaults(props, clazz);
             Properties loadedFromFile = doLoad();
+	        mapValues(loadedFromFile, props, clazz);
             merge(props, loadedFromFile);
             merge(props, reverse(imports));
             return props;
@@ -288,6 +290,15 @@ class PropertiesManager implements Reloadable, Accessible, Mutable {
         for (Map<?, ?> input : inputs)
             results.putAll(input);
     }
+
+	public Object getObject(String key) {
+		readLock.lock();
+		try {
+			return properties.get(key);
+		} finally {
+			readLock.unlock();
+		}
+	}
 
     @Delegate
     public String getProperty(String key) {

--- a/src/test/java/org/aeonbits/owner/variableexpansion/MapPropertiesTest.java
+++ b/src/test/java/org/aeonbits/owner/variableexpansion/MapPropertiesTest.java
@@ -1,0 +1,39 @@
+package org.aeonbits.owner.variableexpansion;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.aeonbits.owner.Config.Sources;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static junit.framework.TestCase.assertNotNull;
+import static org.junit.Assert.assertEquals;
+
+public class MapPropertiesTest {
+	@Sources({"file:${user.dir}/src/test/resources/maps.properties"})
+	public static interface MapConfig extends Config {
+		public String nonmap();
+		
+		@MapValue("map1")
+		public Map<String, String> map1();
+		
+		@MapValue("map2")
+		public Map<String, String> map2();
+	}
+
+	@Test
+	public void testPropertyMaps() {
+		MapConfig config = ConfigFactory.create(MapConfig.class);
+		
+		assertEquals("nope", config.nonmap());
+		
+		assertNotNull(config.map1());
+		assertNotNull(config.map2());
+		
+		assertEquals("a", config.map1().get("value1"));
+		assertEquals("b", config.map1().get("value2"));
+		assertEquals("1", config.map2().get("value3"));
+		assertEquals("2", config.map2().get("value4"));
+	}
+}

--- a/src/test/resources/maps.properties
+++ b/src/test/resources/maps.properties
@@ -1,0 +1,7 @@
+nonmap=nope
+
+map1.value1=a
+map1.value2=b
+
+map2.value3=1
+map2.value4=2


### PR DESCRIPTION
Regarding:
https://github.com/lviggiano/owner/issues/41

Implemented a first version of map based properties. This version supports Map<String, String> currently. Implementing different value types might be much more interesting, considering you might get type conversion errors per-entry.

Sample properties:

```
map1.value1=abc
map1.value2=def
```

Sample class:

```
interface MyConfig extends Config {
    @MapValue("map1")
    Map<String, String> map1();
}
```
