### PR TITLE
Nested configuration interfaces (#129)

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/util/Reflection.java
+++ b/owner/src/main/java/org/aeonbits/owner/util/Reflection.java
@@ -9,6 +9,8 @@
 package org.aeonbits.owner.util;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luigi R. Viggiano
@@ -63,6 +65,25 @@ public final class Reflection {
 
     public static Object invokeDefaultMethod(Object proxy, Method method, Object[] args) throws Throwable {
         return JAVA_8_SUPPORT.invokeDefaultMethod(proxy, method, args);
+    }
+
+    public static List<Class> getAllInterfaces(Class cls) {
+        List<Class> list = new ArrayList<Class>();
+        while (cls != null) {
+            for (Class anInterface : cls.getInterfaces()) {
+                if (!list.contains(anInterface)) {
+                    list.add(anInterface);
+                }
+                List<Class> superInterfaces = getAllInterfaces(anInterface);
+                for (Class superInterface : superInterfaces) {
+                    if (!list.contains(superInterface)) {
+                        list.add(superInterface);
+                    }
+                }
+            }
+            cls = cls.getSuperclass();
+        }
+        return list;
     }
 
 }


### PR DESCRIPTION
This is only an initial draft to get feedback (please don't shoot me :)

This works by doing 2 things -
- a converter that checks if the target type is an
  implementation of the `Config` interface. If it is, then
  any further conversion is handed off to `ConfigFactory` with a
  (configurable)namespace prefix.
- The properties manager, that looks up `@Source` annotation
  will lookup the annotation on all interfaces.

Usage -

``` properties
app.db.username =
app.db.password =

app.jetty.host =
app.jetty.port =
```

``` java
@Config.Sources({"/etc/app.properties"})
public interface BaseConfig extends Accessible {
}

public interface AppConfig extends BaseConfig {
   @DefaultValue("app.db")
    Database db();

    @DefaultValue("app.jetty")
    Jetty jetty();
}

public interface Database extends Accessible {
    @Key("${ns}.username")
    String host();

    @Key("${ns}.password")
    String password();
}

public interface Jetty extends Accessible {
    @Key("${ns}.host")
    String host();

    @Key("${ns}.port")
    int port();
}

```
