### PR TITLE
Add default values handling into string substitutor

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -73,9 +73,10 @@ class StrSubstitutor implements Serializable {
         Matcher m = PATTERN.matcher(source);
         StringBuffer sb = new StringBuffer();
         while (m.find()) {
-            String var = m.group(1);
-            String value = values.getProperty(var);
-            String replacement = (value != null) ? replace(value) : "";
+            String[] var = m.group(1).split(":");
+            String value = values.getProperty(var[0]);
+            String replacement = (value != null) ? replace(value) :
+                    var.length > 1 ? var[1] : ""; // Otherwise try to extract a default value
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         m.appendTail(sb);

--- a/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -39,6 +39,26 @@ public class StrSubstitutorTest {
     }
 
     @Test
+    public void shouldApplyDefaultValues() {
+        Properties values = new Properties();
+        String templateString = "The ${animal:wolf} jumped over the ${target:sheep}.";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("The wolf jumped over the sheep.", resolvedString);
+    }
+
+    @Test
+    public void shouldOverrideDefaultValues() {
+        Properties values = new Properties();
+        values.setProperty("animal", "quick brown fox");
+        values.setProperty("target", "lazy dog");
+        String templateString = "The ${animal:wolf} jumped over the ${target:sheep}.";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("The quick brown fox jumped over the lazy dog.", resolvedString);
+    }
+
+    @Test
     public void shouldReplaceVariablesHavingBackslashes() {
         Properties values = new Properties();
         values.setProperty("animal", "quick\\brown\\fox");


### PR DESCRIPTION
Hello !

That was great that you've added placeholders into configuration path resolver.

But how about adding the ability to set the default values for specific placeholders, if corresponding properties are not specified?

For example ${property:defaultValue}

Just like [Spring's placeholder configurer](https://github.com/spring-projects/spring-framework/issues/9462) supports.
