### PR TITLE
New @Config.Prefix annotation.

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/Config.java
+++ b/owner/src/main/java/org/aeonbits/owner/Config.java
@@ -282,7 +282,8 @@ public interface Config extends Serializable {
      */
     enum DisableableFeature {
         VARIABLE_EXPANSION,
-        PARAMETER_FORMATTING
+        PARAMETER_FORMATTING,
+        PREFIX
     }
 
     /**
@@ -365,6 +366,16 @@ public interface Config extends Serializable {
     @Documented
     @interface PreprocessorClasses {
         Class<? extends Preprocessor>[] value();
+    }
+
+    /**
+     * Specifies simple <code>{@link String}</code> as prefix to properties names.
+     */
+    @Retention(RUNTIME)
+    @Target({TYPE})
+    @Documented
+    @interface Prefix {
+        String value();
     }
 
 }

--- a/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
+++ b/owner/src/main/java/org/aeonbits/owner/PropertiesInvocationHandler.java
@@ -20,7 +20,6 @@ import static org.aeonbits.owner.Config.DisableableFeature.VARIABLE_EXPANSION;
 import static org.aeonbits.owner.Converters.SpecialValue.NULL;
 import static org.aeonbits.owner.Converters.convert;
 import static org.aeonbits.owner.PreprocessorResolver.resolvePreprocessors;
-import static org.aeonbits.owner.PropertiesMapper.key;
 import static org.aeonbits.owner.util.Util.isFeatureDisabled;
 import static org.aeonbits.owner.util.Reflection.invokeDefaultMethod;
 import static org.aeonbits.owner.util.Reflection.isDefault;
@@ -80,7 +79,7 @@ class PropertiesInvocationHandler implements InvocationHandler, Serializable {
 
         // TODO: this if should go away! See #84 and #86
         if (value == null && !isFeatureDisabled(method, VARIABLE_EXPANSION)) {
-            String unexpandedKey = key(method);
+            String unexpandedKey = propertiesManager.propertiesMapper().key(method);
             value = propertiesManager.getProperty(unexpandedKey);
         }
         if (value == null)
@@ -103,7 +102,7 @@ class PropertiesInvocationHandler implements InvocationHandler, Serializable {
     }
 
     private String expandKey(Method method, Object... args) {
-        String key = key(method);
+        String key = propertiesManager.propertiesMapper().key(method);
         if (isFeatureDisabled(method, VARIABLE_EXPANSION))
             return key;
         return substitutor.replace(key, args);

--- a/owner/src/test/java/org/aeonbits/owner/prefix/PrefixKeyExpansionTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/prefix/PrefixKeyExpansionTest.java
@@ -1,0 +1,132 @@
+package org.aeonbits.owner.prefix;
+
+import static org.aeonbits.owner.Config.DisableableFeature.*;
+import static org.aeonbits.owner.util.Collections.map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.aeonbits.owner.Config;
+import org.aeonbits.owner.ConfigFactory;
+import org.aeonbits.owner.Config.*;
+import org.junit.Test;
+
+public class PrefixKeyExpansionTest {
+
+    @Sources("classpath:org/aeonbits/owner/variableexpansion/KeyExpansionExample.xml")
+    @Prefix("servers.${env}.")
+    public interface MyConfig extends Config {
+
+        String name();
+
+        String hostname();
+
+        Integer port();
+
+        String user();
+
+        @DisableFeature(VARIABLE_EXPANSION)
+        String password();
+    }
+
+    @Test
+    public void testKeyExpansion() {
+        MyConfig cfg = ConfigFactory.create(MyConfig.class, map("env", "dev"));
+
+        assertEquals("DEV", cfg.name());
+        assertEquals("devhost", cfg.hostname());
+        assertEquals(new Integer(6000), cfg.port());
+        assertEquals("myuser1", cfg.user());
+        assertNull(cfg.password()); // expansion is disabled on method level
+    }
+
+    @DisableFeature(VARIABLE_EXPANSION)
+    @Sources("classpath:org/aeonbits/owner/variableexpansion/KeyExpansionExample.xml")
+    @Prefix("servers.${env}.")
+    public interface MyConfigWithExpansionDisabled extends Config {
+
+        String name();
+
+        String hostname();
+
+        Integer port();
+
+        String user();
+
+        String password();
+    }
+
+    @Test
+    public void testKeyExpansionDisabled() {
+        MyConfigWithExpansionDisabled cfg = ConfigFactory.create(MyConfigWithExpansionDisabled.class, map("env", "dev"));
+
+        assertNull(cfg.name());
+        assertNull(cfg.hostname());
+        assertNull(cfg.port());
+        assertNull(cfg.user());
+        assertNull(cfg.password());
+    }
+
+    @Sources("classpath:org/aeonbits/owner/variableexpansion/KeyExpansionExample.xml")
+    @Prefix("servers.${env}.")
+    public interface ExpandsFromAnotherKey extends Config {
+
+        @DisableFeature(PREFIX)
+        @DefaultValue("dev")
+        String env();
+
+        String name();
+
+        String hostname();
+
+        Integer port();
+
+        String user();
+
+        @DisableFeature(VARIABLE_EXPANSION)
+        String password();
+    }
+
+    @Test
+    public void testKeyExpansionFromAnotherKey() {
+        ExpandsFromAnotherKey cfg = ConfigFactory.create(ExpandsFromAnotherKey.class);
+
+        assertEquals("DEV", cfg.name());
+        assertEquals("devhost", cfg.hostname());
+        assertEquals(new Integer(6000), cfg.port());
+        assertEquals("myuser1", cfg.user());
+        assertNull(cfg.password()); // expansion is disabled on method level
+    }
+
+    @Test
+    public void testKeyExpansionFromAnotherKeyWithImportOverriding() {
+        ExpandsFromAnotherKey cfg = ConfigFactory.create(ExpandsFromAnotherKey.class, map("env", "uat"));
+
+        assertEquals("UAT", cfg.name());
+        assertEquals("uathost", cfg.hostname());
+        assertEquals(new Integer(60020), cfg.port());
+        assertEquals("myuser2", cfg.user());
+        assertNull("mypass2", cfg.password()); // expansion is disabled on method level
+    }
+
+    @Sources("classpath:org/aeonbits/owner/variableexpansion/KeyExpansionExample.xml")
+    @Prefix("servers.${env}.")
+    public interface UseOfDefaultValueIfNotFound extends Config {
+
+        @DisableFeature(PREFIX)
+        @DefaultValue("dev")
+        String env();
+
+        @Config.Key("nonDefinedInSourceKey")
+        @Config.DefaultValue("wantedValue")
+        String undefinedPropInSource();
+
+    }
+
+    @Test
+    public void testKeyExpansionAndDefaultValue() {
+        UseOfDefaultValueIfNotFound cfg = ConfigFactory.create(UseOfDefaultValueIfNotFound.class);
+
+        assertEquals("dev", cfg.env());
+        assertEquals("wantedValue", cfg.undefinedPropInSource());
+    }
+}

--- a/owner/src/test/java/org/aeonbits/owner/prefix/PrefixSimpleTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/prefix/PrefixSimpleTest.java
@@ -1,0 +1,130 @@
+package org.aeonbits.owner.prefix;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Properties;
+
+import org.aeonbits.owner.Config;
+import static org.aeonbits.owner.Config.Prefix;
+import org.aeonbits.owner.ConfigFactory;
+
+import org.junit.Test;
+
+public class PrefixSimpleTest {
+
+    @Prefix("testprefix.")
+    public interface SampleConfig extends Config {
+        String hello(String param);
+
+        @DefaultValue("Bohemian Rapsody - Queen")
+        String favoriteSong();
+
+        String unspecifiedProperty();
+
+        @Key("server.http.port")
+        int httpPort();
+
+        @Key("salutation.text")
+        @DefaultValue("Good Morning")
+        String salutation();
+
+        @Key("password")
+        @DefaultValue("@#$%^&*()")
+        String password();
+
+        @DefaultValue("foo")
+        void voidMethodWithValue();
+
+        void voidMethodWithoutValue();
+    }
+
+    @Test
+    public void shouldNotReturnNull() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+        assertNotNull(config);
+    }
+
+    @Test
+    public void shouldDoReplacements() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class, new Properties());
+        assertEquals("Hello Luigi.", config.hello("Luigi"));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testVoidMethodWithValue() {
+        SampleConfig cfg = ConfigFactory.create(SampleConfig.class);
+        cfg.voidMethodWithValue();
+    }
+
+    @Test
+    public void testVoidMethodWithoutValue() {
+        SampleConfig cfg = ConfigFactory.create(SampleConfig.class);
+        cfg.voidMethodWithoutValue();
+    }
+
+    static interface StringSubstitutionConfig extends Config {
+        @DefaultValue("Hello Mr. %s!")
+        String helloMr(String name);
+    }
+
+    @Test
+    public void testDefaultStringValue() {
+        StringSubstitutionConfig config = ConfigFactory.create(StringSubstitutionConfig.class);
+        assertEquals("Hello Mr. Luigi!", config.helloMr("Luigi"));
+    }
+
+    @Test
+    public void testDefaultPropertyOverridden() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+        assertEquals("Speechless - Lady Gaga", config.favoriteSong());
+    }
+
+    @Test
+    public void testUnspecifiedProperty() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+        assertNull(config.unspecifiedProperty());
+    }
+
+    @Test
+    public void testPropertyWithCustomizedKey() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+        assertEquals(80, config.httpPort());
+    }
+
+    @Test
+    public void testPropertyWithKeyAndDefaultValue() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+        assertEquals("Good Afternoon", config.salutation());
+    }
+
+    public static interface SubstituteAndFormat extends Config {
+        @DefaultValue("Hello ${mister}")
+        String salutation(String name);
+
+        @DefaultValue("Mr. %s")
+        String mister(String name);
+    }
+
+    @Test
+    public void testSubstitutionAndFormat() {
+        SubstituteAndFormat cfg = ConfigFactory.create(SubstituteAndFormat.class);
+        assertEquals("Hello Mr. Luigi", cfg.salutation("Luigi"));
+        assertEquals("Mr. Luigi", cfg.mister("Luigi"));
+    }
+
+    /**
+     * When a property value contains a '%' character but is not a String format, we
+     * expect the property value to be returned as-is. Under the covers, the
+     * String.format method is used for property expansion. We want to verify a
+     * property value that contains a '%' character but is _not_ a format String is,
+     * indeed, supported.
+     */
+    @Test
+    public void whenPropertyValueIsNotValidFormatString_thenPropertyValueShouldRemainIntact() {
+        SampleConfig config = ConfigFactory.create(SampleConfig.class);
+
+        assertEquals("@#$%^&*()", config.password());
+    }
+}

--- a/owner/src/test/java/org/aeonbits/owner/prefix/PrefixWithSubstitutionTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/prefix/PrefixWithSubstitutionTest.java
@@ -1,0 +1,61 @@
+package org.aeonbits.owner.prefix;
+
+import static org.junit.Assert.assertEquals;
+
+import org.aeonbits.owner.Config;
+import static org.aeonbits.owner.Config.Prefix;
+import org.aeonbits.owner.ConfigFactory;
+import org.junit.Test;
+
+public class PrefixWithSubstitutionTest {
+
+    @Prefix("testprefix.")
+    public interface ConfigWithSubstitutionFile extends Config {
+        String story();
+    }
+
+    @Test
+    public void testConfigWithSubstitutionFile() {
+        ConfigWithSubstitutionFile conf = ConfigFactory.create(ConfigWithSubstitutionFile.class);
+        assertEquals("The quick brown fox jumped over the lazy dog", conf.story());
+    }
+
+    @Test
+    public void testConfigWithSubstitutionAnnotation() {
+        ConfigWithSubstitutionAnnotations conf = ConfigFactory.create(ConfigWithSubstitutionAnnotations.class);
+        assertEquals("The quick brown fox jumped over the lazy dog", conf.story());
+    }
+
+    @Test
+    public void testSubInterface() {
+        ConfigWithSubtstitutionAnnotationsSubInterface conf = ConfigFactory.create(ConfigWithSubtstitutionAnnotationsSubInterface.class);
+        assertEquals("Please grandma, tell me the story of 'The quick brown fox jumped over the lazy dog'", conf.tellmeTheStory());
+    }
+
+    public static interface ConfigWithSubtstitutionAnnotationsSubInterface extends ConfigWithSubstitutionAnnotations {
+        @DefaultValue("grandma")
+        public String teller();
+
+        @DefaultValue("Please ${teller}, tell me the story of '${story}'")
+        public String tellmeTheStory();
+    }
+
+    public static interface ConfigWithSubstitutionAnnotations extends Config {
+
+        @DefaultValue("The ${animal} jumped over the ${target}")
+        String story();
+
+        @DefaultValue("quick ${color} fox")
+        String animal();
+
+        @DefaultValue("${target.attribute} dog")
+        String target();
+
+        @Key("target.attribute")
+        @DefaultValue("lazy")
+        String targetAttribute();
+
+        @DefaultValue("brown")
+        String color();
+    }
+}

--- a/owner/src/test/resources/org/aeonbits/owner/prefix/PrefixSimpleTest$SampleConfig.properties
+++ b/owner/src/test/resources/org/aeonbits/owner/prefix/PrefixSimpleTest$SampleConfig.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2012-2015, Luigi R. Viggiano
+# All rights reserved.
+#
+# This software is distributable under the BSD license.
+# See the terms of the BSD license in the documentation provided with this software.
+#
+
+testprefix.hello=Hello %s.
+testprefix.favoriteSong=Speechless - Lady Gaga
+testprefix.server.http.port=80
+testprefix.salutation.text=Good Afternoon
+testprefix.unsupportedTypeProperty=dummy value: this is unsupported

--- a/owner/src/test/resources/org/aeonbits/owner/prefix/PrefixWithSubstitutionTest$ConfigWithSubstitutionFile.properties
+++ b/owner/src/test/resources/org/aeonbits/owner/prefix/PrefixWithSubstitutionTest$ConfigWithSubstitutionFile.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2012-2015, Luigi R. Viggiano
+# All rights reserved.
+#
+# This software is distributable under the BSD license.
+# See the terms of the BSD license in the documentation provided with this software.
+#
+
+testprefix.story=The ${testprefix.animal} jumped over the ${testprefix.target}
+testprefix.animal=quick ${testprefix.color} fox
+testprefix.target=${testprefix.target.attribute} dog
+testprefix.target.attribute=lazy
+testprefix.color=brown


### PR DESCRIPTION
This is solution for [#259](https://github.com/lviggiano/owner/issues/259)

With new **@Prefix** annotation you can set prifix for all properties in the **Config** interface, 
which helps to avoid **@Key** annotations.

Was:
```java
public interface ExpandsFromAnotherKey extends Config {

    @DefaultValue("dev")
    String env();

    @Key("servers.${env}.name")
    String name();

    @Key("servers.${env}.super.hostname")
    String hostname();

    @Key("servers.${env}.port")
    Integer port();

    @Key("servers.${env}.user")
    String user();

    @DisableFeature(VARIABLE_EXPANSION)
    @Key("servers.${env}.password")
    String password();
}
```

Now:

```java
@Prefix("servers.${env}.")
public interface ExpandsFromAnotherKey extends Config {

    @DisableFeature(PREFIX)
    @DefaultValue("dev")
    String env();

    String name();

    @Key("super.hostname")
    String hostname();

    Integer port();

    String user();

    @DisableFeature(VARIABLE_EXPANSION)
    String password();
}
```