### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ group: edge
 git:
   depth: false
 
+cache:
+  directories:
+  - $HOME/.m2
+
 language: java
 jdk:
   - oraclejdk9


### PR DESCRIPTION
Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.