### PR TITLE
Add support for nested keys

### DIFF
--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -48,7 +48,7 @@ import static java.util.regex.Pattern.compile;
 class StrSubstitutor implements Serializable {
 
     private final Properties values;
-    private static final Pattern PATTERN = compile("\\$\\{(.+?)\\}");
+    private static final Pattern PATTERN = compile("\\$\\{((\\$\\{.+}|.)+?)}");
 
     /**
      * Creates a new instance and initializes it. Uses defaults for variable prefix and suffix and the escaping
@@ -75,7 +75,7 @@ class StrSubstitutor implements Serializable {
         while (m.find()) {
             String var = m.group(1);
             String value = values.getProperty(var);
-            String replacement = (value != null) ? replace(value) : "";
+            String replacement = (value != null) ? replace(value) : (var.matches(PATTERN.pattern())? replace(var): "");
             m.appendReplacement(sb, Matcher.quoteReplacement(replacement));
         }
         m.appendTail(sb);

--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -74,7 +74,6 @@ class StrSubstitutor implements Serializable {
             return null;
         StringBuilder sb = new StringBuilder();
         List<String> groups = getVariableExpansions(source);
-        System.out.println(groups);
         if (groups.isEmpty()) return source;
         for (String group : groups) {
             String value = values.getProperty(group);

--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -85,6 +85,23 @@ class StrSubstitutor implements Serializable {
     }
 
     /**
+     * Returns a string modified in according to supplied source and arguments.<br/>
+     * If the source string has pattern-replacement content like {@code "a.${var}.b"},
+     * the pattern is replaced property value of "var".<br/>
+     * Otherwise the return string is formatted by source and arguments as with {@link String#format(String, Object...)}
+     *
+     * @param source A source formatting format string. {@code null} returns {@code null}
+     * @param args   Arguments referenced by the format specifiers in the source string.
+     * @return formatted string
+     */
+    String replace(String source, Object... args) {
+        if (source == null)
+            return null;
+        Matcher m = PATTERN.matcher(source);
+        return m.find() ? replace(source) : String.format(source, args);
+    }
+
+    /**
      * Finds all top level variable expansion expressions and returns it as a list.
      * E.g.: foo.${bar.${baz}}.${biz} -> [bar.${baz}, biz]
      *
@@ -116,22 +133,5 @@ class StrSubstitutor implements Serializable {
             }
         }
         return variables;
-    }
-
-    /**
-     * Returns a string modified in according to supplied source and arguments.<br/>
-     * If the source string has pattern-replacement content like {@code "a.${var}.b"},
-     * the pattern is replaced property value of "var".<br/>
-     * Otherwise the return string is formatted by source and arguments as with {@link String#format(String, Object...)}
-     *
-     * @param source A source formatting format string. {@code null} returns {@code null}
-     * @param args   Arguments referenced by the format specifiers in the source string.
-     * @return formatted string
-     */
-    String replace(String source, Object... args) {
-        if (source == null)
-            return null;
-        Matcher m = PATTERN.matcher(source);
-        return m.find() ? replace(source) : String.format(source, args);
     }
 }

--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -74,13 +74,13 @@ class StrSubstitutor implements Serializable {
             return null;
         StringBuilder sb = new StringBuilder();
         List<String> groups = getVariableExpansions(source);
-        if (groups.isEmpty()) return source;
+        String replacedSource = source;
         for (String group : groups) {
             String value = values.getProperty(group);
             String replacement = (value != null) ? replace(value) : (group.matches(PATTERN.pattern()) ? replace(group) : "");
-            source = source.replaceFirst(Pattern.quote(String.format("${%s}", group)), Matcher.quoteReplacement(replacement));
+            replacedSource = replacedSource.replaceFirst(Pattern.quote(String.format("${%s}", group)), Matcher.quoteReplacement(replacement));
         }
-        sb.append(source);
+        sb.append(replacedSource);
         return sb.toString();
     }
 

--- a/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
+++ b/owner/src/main/java/org/aeonbits/owner/StrSubstitutor.java
@@ -94,14 +94,15 @@ class StrSubstitutor implements Serializable {
     private List<String> getVariableExpansions(String expression) {
         if (expression == null) return null;
 
-        List<String> variables = new ArrayList<String>();
-        int indexOfFirstVariableExpansion = expression.indexOf("${");
+        final List<String> variables = new ArrayList<String>();
+        final String variableExpressionBeginning = "${";
+        int indexOfFirstVariableExpansion = expression.indexOf(variableExpressionBeginning);
         if (indexOfFirstVariableExpansion == -1) return variables;
 
-        int expressionLength = expression.length();
-        indexOfFirstVariableExpansion += 2;
+        final int expressionLength = expression.length();
+        indexOfFirstVariableExpansion += variableExpressionBeginning.length();
+        final int variableStartIndex = indexOfFirstVariableExpansion;
         int bracketCounter = 1;
-        int variableStartIndex = indexOfFirstVariableExpansion;
 
         for (int index = indexOfFirstVariableExpansion; index < expressionLength; index++) {
             if (expression.charAt(index) == '{') {

--- a/owner/src/test/java/org/aeonbits/owner/ConfigTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/ConfigTest.java
@@ -52,6 +52,16 @@ public class ConfigTest {
         void voidMethodWithValue();
 
         void voidMethodWithoutValue();
+
+        @Key("environment")
+        String env();
+
+        @Key("environments.${environment}.browser")
+        @DefaultValue("chrome")
+        String usedBrowser();
+
+        @Key("environments.${environment}.webdriver.${environments.${environment}.browser}.switches")
+        String webDriverOptions();
     }
 
     @Test
@@ -141,4 +151,16 @@ public class ConfigTest {
         assertEquals ("@#$%^&*()", config.password());
     }
 
+    @Test
+    public void nestedKeyExpansion() {
+        Properties values = new Properties() {{
+            setProperty("environment", "dev");
+            setProperty("environments.dev.browser", "opera");
+            setProperty("environments.dev.webdriver.opera.switches", "foo bar");
+            setProperty("environments.dev.webdriver.chrome.switches", "foo baz");
+        }};
+
+        SampleConfig config = ConfigFactory.create(SampleConfig.class, values);
+        assertEquals("foo bar", config.webDriverOptions());
+    }
 }

--- a/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -86,12 +86,13 @@ public class StrSubstitutorTest {
         Properties values = new Properties();
         values.setProperty("environment", "dev");
         values.setProperty("environments.${environment}.browser", "chrome");
-        values.setProperty("template", "environments.${environment}.webdriver.${environments.${environment}.browser}.switches");
+        values.setProperty("template", "environments.${environment}.webdriver.${environments.${environment}.browser}.switches.${environment}");
         String templateString = "${template}";
         StrSubstitutor sub = new StrSubstitutor(values);
         String resolvedString = sub.replace(templateString);
-        assertEquals("environments.dev.webdriver.chrome.switches", resolvedString);
+        assertEquals("environments.dev.webdriver.chrome.switches.dev", resolvedString);
     }
+
     @Test
     public void testNestedRecursiveResolutionDeepLevel() {
         Properties values = new Properties();
@@ -103,6 +104,17 @@ public class StrSubstitutorTest {
         StrSubstitutor sub = new StrSubstitutor(values);
         String resolvedString = sub.replace(templateString);
         assertEquals("4", resolvedString);
+    }
+
+    @Test
+    public void testPropertyWithCurlyBracketsInName() {
+        Properties values = new Properties();
+        values.setProperty("{foo}", "bar");
+        values.setProperty("template", "foo.${{foo}}");
+        String templateString = "${template}";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("foo.bar", resolvedString);
     }
 
     @Test

--- a/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -82,6 +82,40 @@ public class StrSubstitutorTest {
     }
 
     @Test
+    public void testNestedRecursiveResolution() {
+        Properties values = new Properties();
+        values.setProperty("environment", "dev");
+        values.setProperty("environments.${environment}.browser", "chrome");
+        values.setProperty("template", "environments.${environment}.webdriver.${environments.${environment}.browser}.switches");
+        String templateString = "${template}";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("environments.dev.webdriver.chrome.switches", resolvedString);
+    }
+    @Test
+    public void testNestedRecursiveResolutionDeepLevel() {
+        Properties values = new Properties();
+        values.setProperty("first", "1");
+        values.setProperty("${first}.foo", "2");
+        values.setProperty("${${${first}.foo}}.baz", "3");
+        values.setProperty("${${${${first}.foo}}.baz}.bar", "4");
+        String templateString = "${${${${${first}.foo}}.baz}.bar}";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("4", resolvedString);
+    }
+
+    @Test
+    public void testMultipleNestedResolution() {
+        Properties values = new Properties();
+        values.setProperty("foo", "1");
+        String templateString = "${${${${${${${${foo}}}}}}}}";
+        StrSubstitutor sub = new StrSubstitutor(values);
+        String resolvedString = sub.replace(templateString);
+        assertEquals("1", resolvedString);
+    }
+
+    @Test
     public void testMissingPropertyIsReplacedWithEmptyString() {
         Properties values = new Properties() {{
             setProperty("foo", "fooValue");

--- a/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
+++ b/owner/src/test/java/org/aeonbits/owner/StrSubstitutorTest.java
@@ -85,25 +85,12 @@ public class StrSubstitutorTest {
     public void testNestedRecursiveResolution() {
         Properties values = new Properties();
         values.setProperty("environment", "dev");
-        values.setProperty("environments.${environment}.browser", "chrome");
+        values.setProperty("environments.dev.browser", "chrome");
         values.setProperty("template", "environments.${environment}.webdriver.${environments.${environment}.browser}.switches.${environment}");
         String templateString = "${template}";
         StrSubstitutor sub = new StrSubstitutor(values);
         String resolvedString = sub.replace(templateString);
         assertEquals("environments.dev.webdriver.chrome.switches.dev", resolvedString);
-    }
-
-    @Test
-    public void testNestedRecursiveResolutionDeepLevel() {
-        Properties values = new Properties();
-        values.setProperty("first", "1");
-        values.setProperty("${first}.foo", "2");
-        values.setProperty("${${${first}.foo}}.baz", "3");
-        values.setProperty("${${${${first}.foo}}.baz}.bar", "4");
-        String templateString = "${${${${${first}.foo}}.baz}.bar}";
-        StrSubstitutor sub = new StrSubstitutor(values);
-        String resolvedString = sub.replace(templateString);
-        assertEquals("4", resolvedString);
     }
 
     @Test
@@ -115,16 +102,6 @@ public class StrSubstitutorTest {
         StrSubstitutor sub = new StrSubstitutor(values);
         String resolvedString = sub.replace(templateString);
         assertEquals("foo.bar", resolvedString);
-    }
-
-    @Test
-    public void testMultipleNestedResolution() {
-        Properties values = new Properties();
-        values.setProperty("foo", "1");
-        String templateString = "${${${${${${${${foo}}}}}}}}";
-        StrSubstitutor sub = new StrSubstitutor(values);
-        String resolvedString = sub.replace(templateString);
-        assertEquals("1", resolvedString);
     }
 
     @Test


### PR DESCRIPTION
Current solution does not allow nesting keys in variable expansion for the `＠Key` annnotation.
Let us assume the following scenario:
```java
    @Key("environment")
    @DefaultValue("global")
    String env();

    @Key("environments.${environment}.webdriver.url")
    String webDriverUrl();

    @Key("environments.${environment}.browser")
    @DefaultValue("chrome")
    String usedBrowser();
```
I want to have a property based on the selected _browser_ property which is already based on the selected _environment_ property. I am trying to access the property in the following ways:

1. 

```java
    @Key("environments.${environment}.webdriver.${usedBrowser}.switches")
    String webDriverOptions();
```
2.
```java
    @Key("environments.${environment}.webdriver.${environments.${environment}.browser}.switches")
    String webDriverOptions();
```
but neither solution is working.
This pull request adds ability to nest variable expansion inside `@Key` annotiation.
